### PR TITLE
removing the sourceDirectory property which should default to ""

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -35,4 +35,3 @@ csharp:
   packageName: LukeHagar.PlexAPI.SDK
   packageTags: Plex Media Server SDK
   responseFormat: envelope
-  sourceDirectory: ""


### PR DESCRIPTION
When I manually trigger the SDK generation for C# from the speakeasy dashboard. The pipeline fails, see: https://github.com/LukeHagar/plexcsharp/actions/runs/10970974198/job/30465496056 but it trips over the `sourceDirectory` property which should be allowed to be empty:

See: https://www.speakeasy.com/docs/gen-reference#sourcedirectory => C# =>  `sourceDirectory`

So it's a bug in the validating process which incorrectly marks an empty `sourceDirectory` as  invalid

A workaround seems to be removing the property entirely and that will resolve to "" as well

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed the `sourceDirectory` field from the C# configuration, streamlining the SDK generation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->