### PR TITLE
Use long instead of double for rating keys

### DIFF
--- a/LukeHagar/PlexAPI/SDK/Library.cs
+++ b/LukeHagar/PlexAPI/SDK/Library.cs
@@ -297,7 +297,7 @@ namespace LukeHagar.PlexAPI.SDK
         /// 
         /// </remarks>
         /// </summary>
-        Task<GetMetadataChildrenResponse> GetMetadataChildrenAsync(double ratingKey, string? includeElements = null);
+        Task<GetMetadataChildrenResponse> GetMetadataChildrenAsync(long ratingKey, string? includeElements = null);
 
         /// <summary>
         /// Get Top Watched Content
@@ -2485,7 +2485,7 @@ namespace LukeHagar.PlexAPI.SDK
             throw new Models.Errors.SDKException("Unknown status code received", httpResponse, await httpResponse.Content.ReadAsStringAsync());
         }
 
-        public async Task<GetMetadataChildrenResponse> GetMetadataChildrenAsync(double ratingKey, string? includeElements = null)
+        public async Task<GetMetadataChildrenResponse> GetMetadataChildrenAsync(long ratingKey, string? includeElements = null)
         {
             var request = new GetMetadataChildrenRequest()
             {

--- a/LukeHagar/PlexAPI/SDK/Models/Requests/GetMetadataChildrenRequest.cs
+++ b/LukeHagar/PlexAPI/SDK/Models/Requests/GetMetadataChildrenRequest.cs
@@ -18,7 +18,7 @@ namespace LukeHagar.PlexAPI.SDK.Models.Requests
         /// the id of the library item to return the children of.
         /// </summary>
         [SpeakeasyMetadata("pathParam:style=simple,explode=false,name=ratingKey")]
-        public double RatingKey { get; set; } = default!;
+        public long RatingKey { get; set; } = default!;
 
         /// <summary>
         /// Adds additional elements to the response. Supported types are (Stream)<br/>

--- a/LukeHagar/PlexAPI/SDK/Models/Requests/GetTimelineRequest.cs
+++ b/LukeHagar/PlexAPI/SDK/Models/Requests/GetTimelineRequest.cs
@@ -24,7 +24,7 @@ namespace LukeHagar.PlexAPI.SDK.Models.Requests
         /// The rating key of the media item
         /// </summary>
         [SpeakeasyMetadata("queryParam:style=form,explode=true,name=ratingKey")]
-        public double RatingKey { get; set; } = default!;
+        public long RatingKey { get; set; } = default!;
 
         /// <summary>
         /// The key of the media item to get the timeline for


### PR DESCRIPTION
Addresses Issue#13 (previous code made library requests with decimals in the URLs which is incorrect)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated rating key parameters to use integer values instead of floating-point numbers across metadata and timeline requests, improving type consistency and accuracy in API calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->